### PR TITLE
商品購入機能実装_firstcommit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,8 @@ gem 'devise'
 gem 'active_hash'
 
 gem 'pry-rails'
+
+gem 'payjp'
+
+gem 'gon'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
+    domain_name (0.6.20240107)
     erubi (1.13.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
@@ -109,6 +110,14 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.7)
+      domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -124,6 +133,7 @@ GEM
       activesupport (>= 5.0.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -135,9 +145,14 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.1001)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.6)
     net-imap (0.4.16)
       date
@@ -148,6 +163,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.3)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
@@ -158,6 +174,8 @@ GEM
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.15)
+      rest-client (~> 2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -207,9 +225,16 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.3.7)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
@@ -295,9 +320,11 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
+  payjp
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :configure_permitted_parameters, :initialize_gon, :set_gon, if: :devise_controller?
 
   private
 
@@ -7,5 +7,13 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up,
                                       keys: [:nickname, :password, :password_confirmation, :last_name, :first_name,
                                              :last_name_kana, :first_name_kana, :birth_date])
+  end
+
+  def initialize_gon
+    gon.push({})
+  end
+
+  def set_gon
+    gon.push({})
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,9 @@ class ItemsController < ApplicationController
 
   # 出品者確認
   def check_item_owner
-    redirect_to root_path, alert: '編集権限がありません' if @item.user_id != current_user.id
+    return unless @item.user_id != current_user.id || @item.order.present?
+
+    redirect_to root_path, alert: '編集権限がありません'
   end
 
   # Strong Parameters

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,47 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_item, only: [:index, :create]
+  before_action :check_item_owner, only: [:index, :create]
+
+  def index
+    gon.public_key = ENV['PAYJP_PUBLIC_KEY']
+    @order_shipping = OrderShipping.new
+  end
+
+  def create
+    @order_shipping = OrderShipping.new(order_shipping_params)
+    if @order_shipping.valid?
+      pay_item
+      @order_shipping.save
+      redirect_to root_path, notice: '購入が完了しました'
+    else
+      gon.public_key = ENV['PAYJP_PUBLIC_KEY']
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def order_shipping_params
+    params.require(:order_shipping).permit(:postal_code, :prefecture_id, :city, :address, :building, :phone_number).merge(
+      user_id: current_user.id, item_id: params[:item_id], token: params[:token]
+    )
+  end
+
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
+  def check_item_owner
+    redirect_to root_path if current_user == @item.user || @item.order.present?
+  end
+
+  def pay_item
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp::Charge.create(
+      amount: @item.price, # 商品の支払金額
+      card: order_shipping_params[:token], # トークン
+      currency: 'jpy' # 日本円
+    )
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "./item_price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,33 @@
+const pay = () => {
+  const publicKey = gon.public_key
+  const payjp = Payjp(gon.public_key) // PAY.JPテスト公開鍵
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+        debugger;
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });  
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);
+window.addEventListener("turbo:render", pay);

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_one :order
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :shipping_address
+end

--- a/app/models/order_shipping.rb
+++ b/app/models/order_shipping.rb
@@ -9,7 +9,7 @@ class OrderShipping
     validates :city
     validates :address
     validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'is invalid. Input only number without hyphen' }
-    validates :token, presence: true
+    validates :token
     validates :user_id
     validates :item_id
   end

--- a/app/models/order_shipping.rb
+++ b/app/models/order_shipping.rb
@@ -1,0 +1,31 @@
+class OrderShipping
+  include ActiveModel::Model
+  attr_accessor :postal_code, :prefecture_id, :city, :address, :building, :phone_number, :token, :user_id, :item_id
+
+  # バリデーションの追加
+  with_options presence: true do
+    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :city
+    validates :address
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'is invalid. Input only number without hyphen' }
+    validates :token, presence: true
+    validates :user_id
+    validates :item_id
+  end
+
+  def save
+    # 購入情報を保存
+    order = Order.create(user_id:, item_id:)
+    # 配送先情報を保存
+    ShippingAddress.create(
+      postal_code:,
+      prefecture_id:,
+      city:,
+      address:,
+      building:,
+      phone_number:,
+      order_id: order.id
+    )
+  end
+end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,0 +1,3 @@
+class ShippingAddress < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,6 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
   validates :last_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
   validates :birth_date, presence: true
-
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]+\z/ }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
   validates :last_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
   validates :birth_date, presence: true
-  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]+\z/ }
+
+  has_many :items
+  has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,6 @@
           <%= link_to item_path(item) do %>
            <div class='item-img-content'>
              <%= image_tag item.image, class: 'item-image' if item.image.attached? %>
-             <%# 商品が売れていればsold outを表示しましょう %>
              <%if item.order.present? %> 
                <div class='sold-out'>
                  <span>Sold Out!!</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
            <div class='item-img-content'>
              <%= image_tag item.image, class: 'item-image' if item.image.attached? %>
              <%# 商品が売れていればsold outを表示しましょう %>
-             <%#if item.order.present? %> 
+             <%if item.order.present? %> 
                <div class='sold-out'>
-                 <%# <span>Sold Out!!</span> %>
+                 <span>Sold Out!!</span>
                </div>
-             <%# end %>
+             <% end %>
             </div>
             <div class='item-info'>
               <h3 class='item-name'><%= item.name %></h3>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,15 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" if @item.image.attached? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# if @item.order.present? %>
-      <!--
+      <% if @item.order.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      -->
-      <%# end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -28,12 +24,12 @@
     </div>
 
     <% if user_signed_in? %>
-      <% if current_user.id == @item.user_id %>
+      <% if current_user.id == @item.user_id && @item.order.blank? %>
         <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', item_path(@item), data: {turbo_method: :delete}, class:'item-destroy' %>
-      <% else %>
-        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% elsif @item.order.blank? %>
+        <%= link_to '購入画面に進む', item_orders_path(@item) , data: { turbo: false }, class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,20 +1,25 @@
 <%= render "shared/second-header"%>
 
+<%= include_gon %>
+
 <div class='transaction-contents'>
   <div class='transaction-main'>
     <h1 class='transaction-title-text'>
       購入内容の確認
     </h1>
+
+    <%= render 'shared/error_messages', model: @order_shipping %>
+
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_fee.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +31,12 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_shipping, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap', local: true do |f| %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +84,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :address, class:"input-default", id:"address", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,4 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "item_price", to: "item_price.js"
-
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items, only: [:new, :create, :edit, :update, :show, :index, :destroy]
+  resources :items do
+    resources :orders, only: [:index, :create]
+  root to: 'orders#index'
+  resources :orders, only:[:index, :create]
+  end
 end
 
 

--- a/db/migrate/20241009125106_create_orders.rb
+++ b/db/migrate/20241009125106_create_orders.rb
@@ -3,7 +3,6 @@ class CreateOrders < ActiveRecord::Migration[7.0]
     create_table :orders do |t|
       t.references :user, null: false, foreign_key: true
       t.references :item, null: false, foreign_key: true
-      t.integer :price ,null: false
 
       t.timestamps
     end

--- a/db/migrate/20241009125106_create_orders.rb
+++ b/db/migrate/20241009125106_create_orders.rb
@@ -1,0 +1,11 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.integer :price ,null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241009125328_create_shipping_addresses.rb
+++ b/db/migrate/20241009125328_create_shipping_addresses.rb
@@ -1,0 +1,15 @@
+class CreateShippingAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shipping_addresses do |t|
+      t.string :postal_code
+      t.integer :prefecture_id
+      t.string :city
+      t.string :address
+      t.string :building
+      t.string :phone_number
+      t.references :order, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241012014515_add_price_to_orders.rb
+++ b/db/migrate/20241012014515_add_price_to_orders.rb
@@ -1,0 +1,5 @@
+class AddPriceToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :price, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_05_085433) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_12_014515) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,29 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_05_085433) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "price"
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "shipping_addresses", charset: "utf8", force: :cascade do |t|
+    t.string "postal_code"
+    t.integer "prefecture_id"
+    t.string "city"
+    t.string "address"
+    t.string "building"
+    t.string "phone_number"
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_shipping_addresses_on_order_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -75,4 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_05_085433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
+  add_foreign_key "shipping_addresses", "orders"
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :order_shipping do
+    postal_code    { '123-4567' }
+    prefecture_id  { 2 } # assuming 1 is an invalid value like "--"
+    city           { '横浜市緑区' }
+    address { '青山1-1-1' }
+    building       { '柳ビル103' } # Optional field
+    phone_number   { '09012345678' }
+    token          { 'tok_abcdefghijk00000000000000000' } # Mock token for card
+  end
+end

--- a/spec/factories/shipping_addresses.rb
+++ b/spec/factories/shipping_addresses.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :shipping_address do
+    postal_code { "MyString" }
+    prefecture_id { 1 }
+    city { "MyString" }
+    address { "MyString" }
+    building { "MyString" }
+    phone_number { "MyString" }
+    order { nil }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     nickname              { 'test' }
-    email                 { Faker::Internet.email }
+    email                 { Faker::Internet.unique.email }
     password              { 'password1' }
     password_confirmation { 'password1' }
     first_name            { '山田' }

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe OrderShipping, type: :model do
+  before do
+    # Create a user and an item for the purchase process
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item, user:)
+
+    # Mocking token (assuming you're using a service like PAY.JP)
+    @order_shipping = FactoryBot.build(:order_shipping, user_id: user.id, item_id: item.id,
+                                                        token: 'tok_abcdefghijk00000000000000000')
+    expect(@order_shipping).to be_valid
+    sleep(0.1) # adding sleep to reduce database load (optional)
+  end
+
+  describe '購入情報の保存' do
+    context '購入ができる場合' do
+      it 'すべての値が正しく入力されていれば保存できること' do
+        expect(@order_shipping).to be_valid
+      end
+
+      it '建物名は空でも保存できること' do
+        @order_shipping.building = ''
+        expect(@order_shipping).to be_valid
+      end
+    end
+
+    context '購入ができない場合' do
+      it 'クレジットカード情報が正しくないと保存できないこと' do
+        @order_shipping.token = nil
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Token can't be blank")
+      end
+
+      it '郵便番号が空では保存できないこと' do
+        @order_shipping.postal_code = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Postal code can't be blank")
+      end
+
+      it '郵便番号にハイフンがないと保存できないこと' do
+        @order_shipping.postal_code = '1234567'
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+      end
+
+      it '都道府県が空では保存できないこと' do
+        @order_shipping.prefecture_id = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it '都道府県の情報が0では保存できないこと' do
+        @order_shipping.prefecture_id = 0
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it '市区町村が空では保存できないこと' do
+        @order_shipping.city = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("City can't be blank")
+      end
+
+      it '番地が空では保存できないこと' do
+        @order_shipping.address = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Address can't be blank")
+      end
+
+      it '電話番号が空では保存できないこと' do
+        @order_shipping.phone_number = ''
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Phone number can't be blank")
+      end
+
+      it '電話番号は9桁以下では保存できないこと' do
+        @order_shipping.phone_number = '0901234'
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number without hyphen')
+      end
+
+      it '電話番号は12桁以上では保存できないこと' do
+        @order_shipping.phone_number = '090123456789'
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number without hyphen')
+      end
+
+      it '電話番号はハイフンがあると保存できないこと' do
+        @order_shipping.phone_number = '090-1234-5678'
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number without hyphen')
+      end
+
+      it 'クレジットカード情報が必須であること' do
+        @order_shipping.token = nil
+        @order_shipping.valid?
+        expect(@order_shipping.errors.full_messages).to include("Token can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/shipping_address_spec.rb
+++ b/spec/models/shipping_address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ShippingAddress, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
### What
商品購入機能画面

### Why
商品購入機能を実装するため



▶️必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画 https://gyazo.com/537ebaf599d57144a97e47d6bc983209

▶️入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画 https://gyazo.com/1382a109d233cec12c762eb8ee3e50c0

▶️ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/8225f9b08570bb91b4cd8af629a48c9b

▶️ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画 https://gyazo.com/7e7643241f270f28b8097fe774568a52

▶️ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画 https://gyazo.com/4b5cce1c160062b325be00a8a62fabe4

▶️売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合） https://gyazo.com/565f26328295dc41d54002182d86901e

▶️売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合） https://gyazo.com/6b9d14cf5ab463667c8b685b0d282562

▶️ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合） https://gyazo.com/b0acf3ba8bc11329a429f695a331dd3a

▶️ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合） https://gyazo.com/e8ba77c9e9d4a0abb01888dd3e6e788f

▶️テスト結果の画像
https://gyazo.com/ad88775391bfaa5d5b263cbd6b183f67